### PR TITLE
feat(integration tests): Utilities for testing ansible-trace

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible:
+          - stable-2.11
+          - stable-2.12
+          - stable-2.13
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          path: ansible_collections/mhansen/ansible-trace
+      
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+
+      - name: Install ansible-base (${{ matrix.ansible }})
+        run: pip3 install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+
+      - name: Install test dependencies
+        run: pip3 install pytest mypy pytest-ansible-playbook
+
+      - name: Run integration tests
+        run: pytest -v  $(ls tests/*.py)
+        working-directory: ansible_collections/mhansen/ansible-trace/tests/integration
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 __pycache__
+tests/integration/inventory.ini
+tests/integration/trace
+tests/integration/tests/__pycache__
+tests/integration/tests/.pytest_cache

--- a/plugins/callback/trace.py
+++ b/plugins/callback/trace.py
@@ -10,6 +10,15 @@
 # GNU General Public License for more details.
 
 
+from ansible.plugins.callback import CallbackBase
+from typing import Dict, TextIO
+from datetime import datetime
+from dataclasses import dataclass
+import time
+import os
+import json
+import atexit
+
 DOCUMENTATION = '''
     name: trace
     type: aggregate
@@ -34,16 +43,6 @@ DOCUMENTATION = '''
       - enable in configuration
 '''
 
-import atexit
-import json
-import os
-import time
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Dict, TextIO
-
-from ansible.plugins.callback import CallbackBase
-
 
 class CallbackModule(CallbackBase):
     """
@@ -64,8 +63,10 @@ class CallbackModule(CallbackBase):
     def __init__(self):
         super(CallbackModule, self).__init__()
 
-        self._output_dir: str = os.getenv('TRACE_OUTPUT_DIR', os.path.join(os.path.expanduser('.'), 'trace'))
-        self._hide_task_arguments: str = os.getenv('TRACE_HIDE_TASK_ARGUMENTS', 'False').lower()
+        self._output_dir: str = os.getenv(
+            'TRACE_OUTPUT_DIR', os.path.join(os.path.expanduser('.'), 'trace'))
+        self._hide_task_arguments: str = os.getenv(
+            'TRACE_HIDE_TASK_ARGUMENTS', 'False').lower()
         self._hosts: Dict[Host] = {}
         self._next_pid: int = 1
         self._first: bool = True
@@ -84,7 +85,8 @@ class CallbackModule(CallbackBase):
         if not self._first:
             self._f.write(",\n")
         self._first = False
-        json.dump(e, self._f, sort_keys=True, indent=2) # sort for reproducibility
+        # sort for reproducibility
+        json.dump(e, self._f, sort_keys=True, indent=2)
         self._f.flush()
 
     def v2_runner_on_start(self, host, task):
@@ -128,7 +130,6 @@ class CallbackModule(CallbackBase):
             },
         })
 
-
     def _end_span(self, result, status: str):
         task = result._task
         uuid = task._uuid
@@ -161,6 +162,7 @@ class CallbackModule(CallbackBase):
     def _end(self):
         self._f.write("\n]")
         self._f.close()
+
 
 @dataclass
 class Host:

--- a/tests/integration/ansible.cfg
+++ b/tests/integration/ansible.cfg
@@ -1,0 +1,89 @@
+[defaults]
+# (boolean) By default Ansible will issue a warning when received from a task action (module or action plugin)
+# These warnings can be silenced by adjusting this setting to False.
+;action_warnings=True
+
+# (list) Accept list of cowsay templates that are 'safe' to use, set to empty list if you want to enable all installed templates.
+;cowsay_enabled_stencils=bud-frogs, bunny, cheese, daemon, default, dragon, elephant-in-snake, elephant, eyes, hellokitty, kitty, luke-koala, meow, milk, moofasa, moose, ren, sheep, small, stegosaurus, stimpy, supermilker, three-eyes, turkey, turtle, tux, udder, vader-koala, vader, www
+
+# (string) Specify a custom cowsay path or swap in your cowsay implementation of choice
+;cowpath=
+
+# (string) This allows you to chose a specific cowsay stencil for the banners or use 'random' to cycle through them.
+;cow_selection=default
+
+# (boolean) This option forces color mode even when running without a TTY or the "nocolor" setting is True.
+;force_color=False
+
+# (boolean) This setting allows suppressing colorizing output, which is used to give a better indication of failure and status information.
+;nocolor=False
+
+# (boolean) If you have cowsay installed but want to avoid the 'cows' (why????), use this.
+;nocows=False
+
+# (boolean) Sets the default value for the any_errors_fatal keyword, if True, Task failures will be considered fatal errors.
+;any_errors_fatal=False
+
+# (path) The password file to use for the become plugin. --become-password-file.
+# If executable, it will be run and the resulting stdout will be used as the password.
+;become_password_file=
+
+# (pathspec) Colon separated paths in which Ansible will search for Become Plugins.
+;become_plugins=~/.ansible/plugins/become:/usr/share/ansible/plugins/become
+
+# (string) Chooses which cache plugin to use, the default 'memory' is ephemeral.
+;fact_caching=memory
+
+# (string) Defines connection or path information for the cache plugin
+;fact_caching_connection=
+
+# (string) Prefix to use for cache plugin files/tables
+;fact_caching_prefix=ansible_facts
+
+# (integer) Expiration timeout for the cache plugin data
+;fact_caching_timeout=86400
+
+# (list) Whitelist of callable methods to be made available to template evaluation
+;callable_enabled=
+
+# (list) List of enabled callbacks, not all callbacks need enabling, but many of those shipped with Ansible do as we don't want them activated by default.
+;callbacks_enabled=
+
+# (string) When a collection is loaded that does not support the running Ansible version (via the collection metadata key `requires_ansible`), the default behavior is to issue a warning and continue anyway. Setting this value to `ignore` skips the warning entirely, while setting it to `fatal` will immediately halt Ansible execution.
+;collections_on_ansible_version_mismatch=warning
+
+# (pathspec) Colon separated paths in which Ansible will search for collections content. Collections must be in nested *subdirectories*, not directly in these directories. For example, if ``COLLECTIONS_PATHS`` includes ``~/.ansible/collections``, and you want to add ``my.collection`` to that directory, it must be saved as ``~/.ansible/collections/ansible_collections/my/collection``.
+
+;collections_path=~/.ansible/collections:/usr/share/ansible/collections
+
+# (boolean) A boolean to enable or disable scanning the sys.path for installed collections
+;collections_scan_sys_path=True
+
+# (boolean) Ansible can issue a warning when the shell or command module is used and the command appears to be similar to an existing Ansible module.
+# These warnings can be silenced by adjusting this setting to False. You can also control this at the task level with the module option ``warn``.
+# As of version 2.11, this is disabled by default.
+;command_warnings=False
+
+# (path) The password file to use for the connection plugin. --connection-password-file.
+;connection_password_file=
+
+# (pathspec) Colon separated paths in which Ansible will search for Action Plugins.
+;action_plugins=~/.ansible/plugins/action:/usr/share/ansible/plugins/action
+
+# (boolean) When enabled, this option allows lookup plugins (whether used in variables as ``{{lookup('foo')}}`` or as a loop as with_foo) to return data that is not marked 'unsafe'.
+# By default, such data is marked as unsafe to prevent the templating engine from evaluating any jinja2 templating language, as this could represent a security risk. This option is provided to allow for backward compatibility, however users should first consider adding allow_unsafe=True to any lookups which may be expected to contain data which may be run through the templating engine late
+;allow_unsafe_lookups=False
+
+# (boolean) This controls whether an Ansible playbook should prompt for a login password. If using SSH keys for authentication, you probably do not needed to change this setting.
+;ask_pass=False
+
+# (boolean) This controls whether an Ansible playbook should prompt for a vault password.
+;ask_vault_pass=False
+
+# (pathspec) Colon separated paths in which Ansible will search for Cache Plugins.
+;cache_plugins=~/.ansible/plugins/cache:/usr/share/ansible/plugins/cache
+
+# (pathspec) Colon separated paths in which Ansible will search for Callback Plugins.
+callback_plugins=../../plugins/callback
+callbacks_enabled = trace
+

--- a/tests/integration/basic/basic.yml
+++ b/tests/integration/basic/basic.yml
@@ -1,0 +1,14 @@
+---
+
+- hosts: all
+  environment:
+    CALLBACKS_ENABLED: trace
+    TRACE_OUTPUT_DIR: /ansible_collections/mhansen/ansible-trace
+    TRACE_HIDE_TASK_ARGUMENTS: True
+  tasks:
+    - name: Ping self
+      ansible.builtin.ping:
+
+    - name: Hello world
+      shell: "echo 'hello world!'"
+

--- a/tests/integration/inventories/multiple_hosts.ini
+++ b/tests/integration/inventories/multiple_hosts.ini
@@ -1,0 +1,11 @@
+[all]
+127.0.0.1 ansible_connection=local
+127.0.0.2 ansible_connection=local
+127.0.0.3 ansible_connection=local
+127.0.0.4 ansible_connection=local
+127.0.0.5 ansible_connection=local
+127.0.0.6 ansible_connection=local
+127.0.0.7 ansible_connection=local
+127.0.0.8 ansible_connection=local
+127.0.0.9 ansible_connection=local
+127.0.0.10 ansible_connection=local

--- a/tests/integration/inventories/one_host.ini
+++ b/tests/integration/inventories/one_host.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/tests/integration/tests/basic.py
+++ b/tests/integration/tests/basic.py
@@ -1,10 +1,11 @@
-## Handle integration tests
-
-import pytest
-from utils import get_last_trace, parse_trace
+# Handle integration tests
 from typing import Union, Dict, List, Any
-JSONTYPE = Union[None, int, str, bool, List[Any], Dict[str, Any]]
+from utils import get_last_trace, parse_and_validate_trace
 from event import HostEvent
+import pytest
+
+JSONTYPE = Union[None, int, str, bool, List[Any], Dict[str, Any]]
+
 
 @pytest.mark.ansible_playbook('basic/basic.yml')
 @pytest.mark.ansible_inventory('inventories/multiple_hosts.ini')
@@ -13,7 +14,8 @@ def test_basic_multiple_free(ansible_play):
     trace_hosts: Dict[int, HostEvent]
     trace_events: Dict[int, Any]
     trace_json: JSONTYPE = get_last_trace()
-    trace_hosts, trace_events = parse_trace(trace_json) 
+    trace_hosts, trace_events = parse_and_validate_trace(trace_json)
+
 
 @pytest.mark.ansible_playbook('basic/basic.yml')
 @pytest.mark.ansible_inventory('inventories/multiple_hosts.ini')
@@ -22,7 +24,8 @@ def test_basic_multiple_linear(ansible_play):
     trace_hosts: Dict[int, HostEvent]
     trace_events: Dict[int, Any]
     trace_json: JSONTYPE = get_last_trace()
-    trace_hosts, trace_events = parse_trace(trace_json)
+    trace_hosts, trace_events = parse_and_validate_trace(trace_json)
+
 
 @pytest.mark.ansible_playbook('basic/basic.yml')
 @pytest.mark.ansible_inventory('inventories/one_host.ini')
@@ -31,5 +34,4 @@ def test_basic_single_linear(ansible_play):
     trace_hosts: Dict[int, HostEvent]
     trace_events: Dict[int, Any]
     trace_json: JSONTYPE = get_last_trace()
-    trace_hosts, trace_events = parse_trace(trace_json)
-
+    trace_hosts, trace_events = parse_and_validate_trace(trace_json)

--- a/tests/integration/tests/basic.py
+++ b/tests/integration/tests/basic.py
@@ -1,0 +1,35 @@
+## Handle integration tests
+
+import pytest
+from utils import get_last_trace, parse_trace
+from typing import Union, Dict, List, Any
+JSONTYPE = Union[None, int, str, bool, List[Any], Dict[str, Any]]
+from event import HostEvent
+
+@pytest.mark.ansible_playbook('basic/basic.yml')
+@pytest.mark.ansible_inventory('inventories/multiple_hosts.ini')
+@pytest.mark.ansible_strategy('free')
+def test_basic_multiple_free(ansible_play):
+    trace_hosts: Dict[int, HostEvent]
+    trace_events: Dict[int, Any]
+    trace_json: JSONTYPE = get_last_trace()
+    trace_hosts, trace_events = parse_trace(trace_json) 
+
+@pytest.mark.ansible_playbook('basic/basic.yml')
+@pytest.mark.ansible_inventory('inventories/multiple_hosts.ini')
+@pytest.mark.ansible_strategy('linear')
+def test_basic_multiple_linear(ansible_play):
+    trace_hosts: Dict[int, HostEvent]
+    trace_events: Dict[int, Any]
+    trace_json: JSONTYPE = get_last_trace()
+    trace_hosts, trace_events = parse_trace(trace_json)
+
+@pytest.mark.ansible_playbook('basic/basic.yml')
+@pytest.mark.ansible_inventory('inventories/one_host.ini')
+@pytest.mark.ansible_strategy('linear')
+def test_basic_single_linear(ansible_play):
+    trace_hosts: Dict[int, HostEvent]
+    trace_events: Dict[int, Any]
+    trace_json: JSONTYPE = get_last_trace()
+    trace_hosts, trace_events = parse_trace(trace_json)
+

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+from fixtures import ansible_play
+

--- a/tests/integration/tests/event.py
+++ b/tests/integration/tests/event.py
@@ -1,0 +1,46 @@
+import re
+
+class Event:
+
+    pid: int
+    name: str
+    ph: str
+
+    def __init__(self, dict):
+        if not 'pid' in dict:
+            raise ValueError('Event must be linked to pid')
+        self.pid = dict['pid']
+        self.ph = dict['ph']
+
+class DurationEvent(Event):
+
+    id: int
+    ts: float
+
+    def __init__(self, dict):
+        if not 'id' in dict:
+            raise ValueError('Duration event needs to have id')
+        self.id = dict['id']
+        if not 'ts' in dict:
+            raise ValueError('Duration event {} needs to have a timestamp'.format(self.id))
+        if not 'name' in dict:
+            raise ValueError('Duration event {} needs to have a name'.format(self.id))
+        if not 'ph' in dict or not re.search("^(B|E)$", dict['ph']):
+            raise ValueError('Duration event {} needs to have a ph either set to B or E'.format(self.id))
+        self.ts = dict['ts']
+        self.name = dict['name']
+
+        super().__init__(dict)
+
+class HostEvent(Event):
+
+    def __init__(self, dict):
+        if not 'ph' in dict or dict['ph'] != 'M':
+            raise ValueError('Host event needs to have a ph set to M')
+        if not 'args' in dict or not 'name' in dict['args']:
+            raise ValueError('Host events needs to have name')
+
+        self.name = dict['args']['name']
+
+        super().__init__(dict)
+

--- a/tests/integration/tests/fixtures.py
+++ b/tests/integration/tests/fixtures.py
@@ -1,0 +1,27 @@
+import pytest
+import os
+from pytest_ansible_playbook import runner
+
+@pytest.fixture
+def ansible_play(request):
+   
+    # Get required marks, raise exception if not defined or invalid params 
+    inventory = request.node.get_closest_marker('ansible_inventory').args[0]
+    strategy = request.node.get_closest_marker('ansible_strategy').args[0]
+    playbook = request.node.get_closest_marker('ansible_playbook').args[0]
+
+    # Set params for ansible runner
+    request.config.option.ansible_playbook_directory = "."
+    request.config.option.ansible_playbook_inventory = "inventory.ini"
+
+    # Assign strategy
+    os.environ["ANSIBLE_STRATEGY"] = strategy
+    
+    # Assign inventory (we use symlink)
+    os.symlink(inventory, 'inventory.ini.tmp')
+    os.rename('inventory.ini.tmp', 'inventory.ini');
+
+    # Test required playbook
+    with runner(request, [playbook]):
+        yield
+

--- a/tests/integration/tests/fixtures.py
+++ b/tests/integration/tests/fixtures.py
@@ -1,27 +1,23 @@
-import pytest
 import os
+import pytest
 from pytest_ansible_playbook import runner
+
 
 @pytest.fixture
 def ansible_play(request):
-   
-    # Get required marks, raise exception if not defined or invalid params 
+
+    # Get required marks, raise exception if not defined or invalid params
     inventory = request.node.get_closest_marker('ansible_inventory').args[0]
     strategy = request.node.get_closest_marker('ansible_strategy').args[0]
     playbook = request.node.get_closest_marker('ansible_playbook').args[0]
 
     # Set params for ansible runner
     request.config.option.ansible_playbook_directory = "."
-    request.config.option.ansible_playbook_inventory = "inventory.ini"
+    request.config.option.ansible_playbook_inventory = inventory
 
     # Assign strategy
     os.environ["ANSIBLE_STRATEGY"] = strategy
-    
-    # Assign inventory (we use symlink)
-    os.symlink(inventory, 'inventory.ini.tmp')
-    os.rename('inventory.ini.tmp', 'inventory.ini');
 
     # Test required playbook
     with runner(request, [playbook]):
         yield
-

--- a/tests/integration/tests/pytest.ini
+++ b/tests/integration/tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers = 
+    ansible_strategy
+    ansible_playbook
+    ansible_inventory

--- a/tests/integration/tests/utils.py
+++ b/tests/integration/tests/utils.py
@@ -3,37 +3,48 @@ import json
 import glob
 import re
 from collections import deque
-from typing import Union, Dict, List, Any, TextIO, NewType, Deque, Tuple
+from typing import Union, Dict, List, Any, TextIO, Deque, Tuple
 from event import HostEvent, DurationEvent
 
 JSONTYPE = Union[None, int, str, bool, List[Any], Dict[str, Any]]
 
+
 def get_last_trace() -> JSONTYPE:
     list_of_files: List[str] = glob.glob('trace/*')
     latest_file: str = max(list_of_files, key=os.path.getctime)
-    
-    f: TextIO = open(latest_file)
-    trace_json: JSONTYPE = json.load(f)
-    f.close()
+
+    file: TextIO = open(latest_file, encoding="utf-8")
+    trace_json: JSONTYPE = json.load(file)
+    file.close()
     return trace_json
 
-def parse_trace(trace: JSONTYPE) -> Tuple[Dict[int, HostEvent], Dict[int, Any]]:
+
+def parse_and_validate_trace(trace: JSONTYPE) -> Tuple[Dict[int, HostEvent],
+                                                       Dict[int, Any]]:
     hosts: Dict[int, HostEvent] = {}
-    duration_events: Dict[int, Any]  = {}
+    duration_events: Dict[int, Any] = {}
     duration_stacks: Dict[int, Deque] = {}
 
     # Parse events in trace
     for event in trace:
         if 'ph' in event and event['ph'] == 'M':
-            hosts, duration_events, duration_stacks = add_hosts(hosts, duration_events, duration_stacks, event)
+            hosts, duration_events, duration_stacks = add_hosts(
+                hosts, duration_events, duration_stacks, event)
         elif 'ph' in event and re.search("^(B|E)$", event['ph']):
-            duration_events, duration_stacks = add_duration_event(hosts, duration_events, duration_stacks, event)  
+            duration_events, duration_stacks = add_duration_event(
+                hosts, duration_events, duration_stacks, event)
         else:
-           raise ValueError('Event cannot be handled') 
+            raise ValueError('Event cannot be handled')
 
     return (hosts, duration_events)
 
-def add_hosts(hosts: Dict[int, HostEvent], duration_events: Dict[int, Any], duration_stacks: Dict[int, Deque], event_hash: Any) -> Tuple[Dict[int, HostEvent], Dict[int, Any], Dict[int, Deque]]:
+
+def add_hosts(
+        hosts: Dict[int, HostEvent],
+        duration_events: Dict[int, Any],
+        duration_stacks: Dict[int, Deque],
+        event_hash: Any) -> Tuple[Dict[int, HostEvent],
+                                  Dict[int, Any], Dict[int, Deque]]:
 
     event = HostEvent(event_hash)
 
@@ -43,53 +54,74 @@ def add_hosts(hosts: Dict[int, HostEvent], duration_events: Dict[int, Any], dura
 
     return (hosts, duration_events, duration_stacks)
 
-def add_duration_event(hosts: Dict[int, HostEvent], events: Dict[int, Any], curr_stacks: Dict[int, Deque], event_hash: Any) -> Tuple[Dict[int, Any], Dict[int, Deque]]:
-   
+
+def add_duration_event(
+        hosts: Dict[int, HostEvent],
+        events: Dict[int, Any],
+        curr_stacks: Dict[int, Deque],
+        event_hash: Any) -> Tuple[Dict[int, Any], Dict[int, Deque]]:
+
     event = DurationEvent(event_hash)
 
-    if not event.pid in hosts:
-        raise ValueError('Duration event {} host with pid {} does not match any registered host'.format(event.id, event.pid))
+    if event.pid not in hosts:
+        raise ValueError(
+            f'Duration event {event.id} host with pid {event.pid}'
+            'does not match any registered host')
 
     if event.ph == 'B':
 
         # Check if event already exists
         if event.id in events[event.pid]:
-            raise ValueError('Event {} already registered'.format(event.id))
+            raise ValueError(f'Event {event.id} already registered')
 
         events[event.pid][event.id] = {'B': event, 'children_ids': []}
 
-        # If there is event in stack, must declare this event as child of last event in stack
+        # If there is event in stack, must declare this event as child of last
+        # event in stack
         if curr_stacks[event.pid]:
             parent_id: int = curr_stacks[event.pid][-1]
-            if not parent_id in events[event.pid]:
-                raise ValueError('Event id {} in stack, is not present in host events'.format(parent_id))
+            if parent_id not in events[event.pid]:
+                raise ValueError(
+                    f'Event id {parent_id} in stack, '
+                    'is not present in host events')
 
             # Check if child timestamp is inferior or equal to parent
             if events[event.pid][parent_id]['B'].ts > event.ts:
-                raise ValueError('Event id {} begin timestamp {} is inferior to its parent id {} with timestamp {}'.format(event.id, event.ts, events[event.pid][parent_id]['B'].id, events[event.pid][parent_id]['B'].ts))
+                raise ValueError(f'Event id {event.id}'
+                                 f'begin timestamp {event.ts}'
+                                 'is inferior to its parent id'
+                                 f'{events[event.pid][parent_id]["B"].id}'
+                                 'with timestamp'
+                                 f'{events[event.pid][parent_id]["B"].ts}')
 
             events[event.pid][parent_id]['children_ids'].append(event.id)
             events[event.pid][event.id]['parent_id'] = parent_id
 
         curr_stacks[event.pid].append(event.id)
         return (events, curr_stacks)
-    
+
     if event.ph == 'E':
 
         # Check if there is B event
-        if not event.id in events[event.pid] or not 'B' in events[event.pid][event.id]:
-            raise ValueError('Event {} is not registered'.format(event.id))
+        if (event.id not in events[event.pid]
+                or 'B' not in events[event.pid][event.id]):
+            raise ValueError(f'Event {event.id} is not registered')
 
         # Check if timestamp is superior or equal to B event
         if events[event.pid][event.id]['B'].ts > event.ts:
-            raise ValueError('Event id {} timestamp {} is lower than its begin event with timestamp {}'.format(event.id, event.ts, events[event.pid][event.id]['B'].ts))
+            raise ValueError(f'Event id {event.id} timestamp {event.ts}'
+                             'is lower than its begin event with timestamp'
+                             f'{events[event.pid][event.id]["B"].ts}')
 
         # Check we don't have children event not yet ended
-        if not curr_stacks[event.pid] or curr_stacks[event.pid][-1] != event.id:
-            raise ValueError('Cannot end event id {} if I have child that are not yet ended (id {} ongoing)'.format(event.id, curr_stacks[event.pid][-1]))
+        if(not curr_stacks[event.pid]
+                or curr_stacks[event.pid][-1] != event.id):
+            raise ValueError(
+                f'Cannot end event id {event.id}'
+                'if I have child that are not yet ended'
+                f'(id {curr_stacks[event.pid][-1]} ongoing)')
 
         events[event.pid][event.id]['E'] = event
         curr_stacks[event.pid].pop()
 
     return (events, curr_stacks)
-

--- a/tests/integration/tests/utils.py
+++ b/tests/integration/tests/utils.py
@@ -1,0 +1,95 @@
+import os
+import json
+import glob
+import re
+from collections import deque
+from typing import Union, Dict, List, Any, TextIO, NewType, Deque, Tuple
+from event import HostEvent, DurationEvent
+
+JSONTYPE = Union[None, int, str, bool, List[Any], Dict[str, Any]]
+
+def get_last_trace() -> JSONTYPE:
+    list_of_files: List[str] = glob.glob('trace/*')
+    latest_file: str = max(list_of_files, key=os.path.getctime)
+    
+    f: TextIO = open(latest_file)
+    trace_json: JSONTYPE = json.load(f)
+    f.close()
+    return trace_json
+
+def parse_trace(trace: JSONTYPE) -> Tuple[Dict[int, HostEvent], Dict[int, Any]]:
+    hosts: Dict[int, HostEvent] = {}
+    duration_events: Dict[int, Any]  = {}
+    duration_stacks: Dict[int, Deque] = {}
+
+    # Parse events in trace
+    for event in trace:
+        if 'ph' in event and event['ph'] == 'M':
+            hosts, duration_events, duration_stacks = add_hosts(hosts, duration_events, duration_stacks, event)
+        elif 'ph' in event and re.search("^(B|E)$", event['ph']):
+            duration_events, duration_stacks = add_duration_event(hosts, duration_events, duration_stacks, event)  
+        else:
+           raise ValueError('Event cannot be handled') 
+
+    return (hosts, duration_events)
+
+def add_hosts(hosts: Dict[int, HostEvent], duration_events: Dict[int, Any], duration_stacks: Dict[int, Deque], event_hash: Any) -> Tuple[Dict[int, HostEvent], Dict[int, Any], Dict[int, Deque]]:
+
+    event = HostEvent(event_hash)
+
+    hosts[event.pid] = event
+    duration_events[event.pid] = {}
+    duration_stacks[event.pid] = deque()
+
+    return (hosts, duration_events, duration_stacks)
+
+def add_duration_event(hosts: Dict[int, HostEvent], events: Dict[int, Any], curr_stacks: Dict[int, Deque], event_hash: Any) -> Tuple[Dict[int, Any], Dict[int, Deque]]:
+   
+    event = DurationEvent(event_hash)
+
+    if not event.pid in hosts:
+        raise ValueError('Duration event {} host with pid {} does not match any registered host'.format(event.id, event.pid))
+
+    if event.ph == 'B':
+
+        # Check if event already exists
+        if event.id in events[event.pid]:
+            raise ValueError('Event {} already registered'.format(event.id))
+
+        events[event.pid][event.id] = {'B': event, 'children_ids': []}
+
+        # If there is event in stack, must declare this event as child of last event in stack
+        if curr_stacks[event.pid]:
+            parent_id: int = curr_stacks[event.pid][-1]
+            if not parent_id in events[event.pid]:
+                raise ValueError('Event id {} in stack, is not present in host events'.format(parent_id))
+
+            # Check if child timestamp is inferior or equal to parent
+            if events[event.pid][parent_id]['B'].ts > event.ts:
+                raise ValueError('Event id {} begin timestamp {} is inferior to its parent id {} with timestamp {}'.format(event.id, event.ts, events[event.pid][parent_id]['B'].id, events[event.pid][parent_id]['B'].ts))
+
+            events[event.pid][parent_id]['children_ids'].append(event.id)
+            events[event.pid][event.id]['parent_id'] = parent_id
+
+        curr_stacks[event.pid].append(event.id)
+        return (events, curr_stacks)
+    
+    if event.ph == 'E':
+
+        # Check if there is B event
+        if not event.id in events[event.pid] or not 'B' in events[event.pid][event.id]:
+            raise ValueError('Event {} is not registered'.format(event.id))
+
+        # Check if timestamp is superior or equal to B event
+        if events[event.pid][event.id]['B'].ts > event.ts:
+            raise ValueError('Event id {} timestamp {} is lower than its begin event with timestamp {}'.format(event.id, event.ts, events[event.pid][event.id]['B'].ts))
+
+        # Check we don't have children event not yet ended
+        if not curr_stacks[event.pid] or curr_stacks[event.pid][-1] != event.id:
+            raise ValueError('Cannot end event id {} if I have child that are not yet ended (id {} ongoing)'.format(event.id, curr_stacks[event.pid][-1]))
+
+        events[event.pid][event.id]['E'] = event
+        curr_stacks[event.pid].pop()
+
+    return (events, curr_stacks)
+


### PR DESCRIPTION
Hello everyone :wave: !

This is the first step for #10 

This proposition allow creating tests using pytest framework where we can chose strategy, inventory for the same playbook file (see tests/integration/tests/basic.py)
I have also made some utilities functions that parse trace to ensure its integrity.
This include also related github action CI.yml (here a [sample](https://github.com/louisquentinjoucla/ansible-trace/actions/runs/2482547964))

Waiting for your feedback,
Thanks!