### PR TITLE
feat(play): Add play level trace span

### DIFF
--- a/tests/integration/inventories/multiple_hosts.ini
+++ b/tests/integration/inventories/multiple_hosts.ini
@@ -9,3 +9,16 @@
 127.0.0.8 ansible_connection=local
 127.0.0.9 ansible_connection=local
 127.0.0.10 ansible_connection=local
+
+[group_a]
+127.0.0.1 ansible_connection=local
+127.0.0.2 ansible_connection=local
+127.0.0.8 ansible_connection=local
+127.0.0.9 ansible_connection=local
+127.0.0.10 ansible_connection=local
+
+[group_b]
+127.0.0.8 ansible_connection=local
+127.0.0.9 ansible_connection=local
+127.0.0.10 ansible_connection=local
+127.0.0.11 ansible_connection=local

--- a/tests/integration/inventories/one_host.ini
+++ b/tests/integration/inventories/one_host.ini
@@ -1,2 +1,8 @@
 [all]
 localhost ansible_connection=local
+
+[group_a]
+127.0.0.1 ansible_connection=local
+
+[group_b]
+127.0.0.1 ansible_connection=local

--- a/tests/integration/plays/base.yml
+++ b/tests/integration/plays/base.yml
@@ -1,0 +1,17 @@
+---
+
+- hosts: group_a
+  name: First play
+  environment:
+    CALLBACKS_ENABLED: trace
+    TRACE_OUTPUT_DIR: /ansible_collections/mhansen/ansible-trace
+    TRACE_HIDE_TASK_ARGUMENTS: True
+  tasks:
+    - name: One task before import
+      shell: "echo 'Play 1'"
+
+- name: Second play
+  import_playbook: otherplays.yml
+
+- name: Third play
+  import_playbook: nested.yml

--- a/tests/integration/plays/nested.yml
+++ b/tests/integration/plays/nested.yml
@@ -1,0 +1,15 @@
+---
+
+- hosts: group_b
+  name: Third play
+  environment:
+    CALLBACKS_ENABLED: trace
+    TRACE_OUTPUT_DIR: /ansible_collections/mhansen/ansible-trace
+    TRACE_HIDE_TASK_ARGUMENTS: True
+  tasks:
+    - name: Random task
+      shell: "echo 'Hello world'"
+
+- name: Nested play
+  import_playbook: otherplays.yml
+

--- a/tests/integration/plays/otherplays.yml
+++ b/tests/integration/plays/otherplays.yml
@@ -1,0 +1,12 @@
+---
+
+- hosts: group_a
+  name: Random play
+  environment:
+    CALLBACKS_ENABLED: trace
+    TRACE_OUTPUT_DIR: /ansible_collections/mhansen/ansible-trace
+    TRACE_HIDE_TASK_ARGUMENTS: True
+  tasks:
+    - name: A fake task
+      shell: "echo 'hello there'"
+

--- a/tests/integration/tests/plays.py
+++ b/tests/integration/tests/plays.py
@@ -1,0 +1,37 @@
+# Handle integration tests
+from typing import Union, Dict, List, Any
+from utils import get_last_trace, parse_and_validate_trace
+from event import HostEvent
+import pytest
+
+JSONTYPE = Union[None, int, str, bool, List[Any], Dict[str, Any]]
+
+
+@pytest.mark.ansible_playbook('plays/base.yml')
+@pytest.mark.ansible_inventory('inventories/multiple_hosts.ini')
+@pytest.mark.ansible_strategy('free')
+def test_basic_multiple_free(ansible_play):
+    trace_hosts: Dict[int, HostEvent]
+    trace_events: Dict[int, Any]
+    trace_json: JSONTYPE = get_last_trace()
+    trace_hosts, trace_events = parse_and_validate_trace(trace_json)
+
+
+@pytest.mark.ansible_playbook('plays/base.yml')
+@pytest.mark.ansible_inventory('inventories/multiple_hosts.ini')
+@pytest.mark.ansible_strategy('linear')
+def test_basic_multiple_linear(ansible_play):
+    trace_hosts: Dict[int, HostEvent]
+    trace_events: Dict[int, Any]
+    trace_json: JSONTYPE = get_last_trace()
+    trace_hosts, trace_events = parse_and_validate_trace(trace_json)
+
+
+@pytest.mark.ansible_playbook('plays/base.yml')
+@pytest.mark.ansible_inventory('inventories/one_host.ini')
+@pytest.mark.ansible_strategy('linear')
+def test_basic_single_linear(ansible_play):
+    trace_hosts: Dict[int, HostEvent]
+    trace_events: Dict[int, Any]
+    trace_json: JSONTYPE = get_last_trace()
+    trace_hosts, trace_events = parse_and_validate_trace(trace_json)


### PR DESCRIPTION
Hey :wave: ,

This PR close #3 ! Here how it does looks like with all playbooks with strategy free:
![image](https://user-images.githubusercontent.com/28892335/174470206-1ec85219-88ea-4915-a294-e72c9c555e5a.png)

It is not accurate as we lack of callback to achieve this, but here how it is done:
The play duration event will only be created right before when a task for a given host will start. At the start of a new play, we add an E event for all the plays we created before.

We do one as well at the very end to handle the last play condition.

Even if it is not accurate, it gives a better pictures of what is going on.

Let me know if it is ok for you!